### PR TITLE
Remove unnecessary inheritance

### DIFF
--- a/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
+++ b/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
@@ -8,6 +8,8 @@ import edu.stanford.protege.metaproject.api.UserId;
 import org.junit.Before;
 import org.protege.editor.owl.client.LocalHttpClient;
 
+import static com.clarkparsia.pellet.server.protege.TestUtilities.*;
+
 /**
  * @author Edgar Rodriguez-Diaz
  */

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * @author Edgar Rodriguez-Diaz
  */
-public abstract class ProtegeServerTest extends TestUtilities {
+public abstract class ProtegeServerTest {
 	private static HTTPServer mServer;
 
 	protected static File TEST_HOME;


### PR DESCRIPTION
The parent class only has static fields. Those can just as easily be accessed
manually.