### PR TITLE
Attempt to fix restart tests

### DIFF
--- a/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
+++ b/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
@@ -43,16 +43,12 @@ public abstract class PelletClientTest extends ProtegeServerTest {
 		pelletServer.start();
 	}
 
-	public void stopPelletServer() {
+	@After
+	public void after() throws Exception {
 		if (pelletServer != null) {
 			pelletServer.stop();
 			pelletServer = null;
 		}
-	}
-
-	@After
-	public void after() throws Exception {
-		stopPelletServer();
 		super.after();
 	}
 }

--- a/client/src/test/java/com/complexible/pellet/client/PelletServiceTest.java
+++ b/client/src/test/java/com/complexible/pellet/client/PelletServiceTest.java
@@ -75,10 +75,18 @@ public class PelletServiceTest extends PelletClientTest {
 	}
 
 	@Test
-	public void restartPellet() {
+	public void restartPellet() throws Exception {
 		PelletService aService = serviceProvider.get();
 		Integer v1 = ClientTools.executeCall(aService.version(agencyOntId, ID));
-		ClientTools.executeCall(serviceProvider.get().restart());
+		ClientTools.executeCall(aService.restart());
+
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		aService = serviceProvider.get();
 		Integer v2 = ClientTools.executeCall(aService.version(agencyOntId, ID));
 		assertEquals(v1, v2);
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
@@ -96,6 +96,7 @@ public final class PelletServer {
 		router.add("GET", "/admin/restart", new HttpHandler() {
 			@Override
 			public void handleRequest(HttpServerExchange exchange) throws Exception {
+				LOGGER.info("Restarting server");
 				aShutdownHandler.shutdown();
 				aShutdownHandler.addShutdownListener(new GracefulShutdownHandler.ShutdownListener() {
 					@Override
@@ -108,7 +109,7 @@ public final class PelletServer {
 								throw new RuntimeException(e);
 							}
 						} else {
-							Logger.getLogger(PelletServer.class.getName()).warning("Failed to shutown when restarting");
+							LOGGER.warning("Failed to shutown when restarting");
 						}
 					}
 				});


### PR DESCRIPTION
@bionne i'm not sure why this restart is failing. I'm getting a 500 on this
version call after restarting the server. Am I missing some initialization
before the restart call is allowed?

```
com.google.common.util.concurrent.UncheckedExecutionException:
java.lang.IllegalStateException: Manager on ontology
OntologyID(OntologyIRI(<http://www.owl-ontologies.com/unnamed.owl>)
VersionIRI(<null>)) is null; the ontology is no longer associated to a manager.
Ensure the ontology is not being used after being removed from its manager.
at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2203) ~[guava-18.0.jar:na]
at com.google.common.cache.LocalCache.get(LocalCache.java:3937) ~[guava-18.0.jar:na]
at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3941) ~[guava-18.0.jar:na]
at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4824) ~[guava-18.0.jar:na]
at com.clarkparsia.pellet.server.model.impl.OntologyStateImpl.getClient(OntologyStateImpl.java:132) ~[classes/:na]
at com.clarkparsia.pellet.server.handlers.AbstractRoutingHandler.getClientState(AbstractRoutingHandler.java:79)
~[classes/:na]
at com.clarkparsia.pellet.server.handlers.ReasonerVersionHandler.handleRequest(ReasonerVersionHandler.java:32)
~[classes/:na]
at io.undertow.server.Connectors.executeRootHandler(Connectors.java:198) ~[undertow-core-1.3.4.Final.jar:1.3.4.Final]
at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:788) [undertow-core-1.3.4.Final.jar:1.3.4.Final]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_121]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_121]
at java.lang.Thread.run(Thread.java:745) [na:1.8.0_121]
Caused by: java.lang.IllegalStateException: Manager on ontology
OntologyID(OntologyIRI(<http://www.owl-ontologies.com/unnamed.owl>)
VersionIRI(<null>)) is null; the ontology is no longer associated to a
manager. Ensure the ontology is not being used after being removed from
its manager.
at org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull(OWLAPIPreconditions.java:61)
~[classes/:na]
at uk.ac.manchester.cs.owl.owlapi.OWLImmutableOntologyImpl.getOWLOntologyManager(OWLImmutableOntologyImpl.java:103)
~[classes/:na]
at uk.ac.manchester.cs.owl.owlapi.concurrent.ConcurrentOWLOntologyImpl.getOWLOntologyManager(ConcurrentOWLOntologyImpl.java:107)
~[classes/:na]
at com.clarkparsia.modularity.IncrementalReasoner.<init>(IncrementalReasoner.java:248)
~[classes/:na]
at com.clarkparsia.modularity.IncrementalReasoner.copy(IncrementalReasoner.java:262) ~[clas
```