### PR TITLE
Remove unnecessary admin client from pellet server state

### DIFF
--- a/cli/src/main/java/pellet/PelletServer.java
+++ b/cli/src/main/java/pellet/PelletServer.java
@@ -100,12 +100,6 @@ public class PelletServer extends PelletCmdApp {
 		aPelletServer.start();
 	}
 
-	private PelletService service(String endpoint) {
-		Injector aInjector = Guice.createInjector(new ClientModule(endpoint));
-
-		return aInjector.getInstance(PelletService.class);
-	}
-
 	private void stopServer(final String[] args) throws IOException {
 		String endpoint;
 		if (args.length > 1) {
@@ -116,7 +110,9 @@ public class PelletServer extends PelletCmdApp {
 			endpoint = settings.endpoint();
 		}
 
-		Call<Void> shutdownCall = service(endpoint).shutdown();
+		Injector aInjector = Guice.createInjector(new ClientModule(endpoint));
+
+		Call<Void> shutdownCall = aInjector.getInstance(PelletService.class).shutdown();
 		ClientTools.executeCall(shutdownCall);
 
 		System.out.println("Pellet server is shutting down");

--- a/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerFactory.java
+++ b/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerFactory.java
@@ -30,9 +30,7 @@ public class PelletReasonerFactory extends AbstractProtegeOWLReasonerInfo {
 	public PelletReasonerFactory() {
 	}
 
-	/**
-     * {@inheritDoc}
-     */
+	@Override
     public OWLReasonerFactory getReasonerFactory() {
 	    if (factory == null) {
 		    // enable/disable tracing based on the preference
@@ -61,9 +59,7 @@ public class PelletReasonerFactory extends AbstractProtegeOWLReasonerInfo {
 	    }
     }
 
-	/**
-     * {@inheritDoc}
-     */
+	@Override
     public BufferingMode getRecommendedBuffering() {
 
 	    PelletReasonerMode reasonerMode = prefs.getReasonerMode();

--- a/server/src/main/java/com/clarkparsia/pellet/server/protege/model/ProtegeOntologyState.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/protege/model/ProtegeOntologyState.java
@@ -99,17 +99,17 @@ public class ProtegeOntologyState implements OntologyState {
 		this.projectId = projectId;
 		this.remoteOnt = client.openProject(projectId).serverDocument;
 
-		this.revision = readRevision(path);
+		this.revision = readRevision();
 		this.snapshotLoaded = revision.getRevisionNumber() > 0;
 		writeRevision();
 	}
 
-	private static File revisionFile(final Path path) throws IOException {
+	public File revisionFile() throws IOException {
 		return path.resolveSibling("HEAD").toFile();
 	}
 
-	private static DocumentRevision readRevision(final Path path) throws IOException {
-		final File aHeadFile = revisionFile(path);
+	private DocumentRevision readRevision() throws IOException {
+		final File aHeadFile = revisionFile();
 
 		if (aHeadFile.exists()) {
 			return DocumentRevision.create(Integer.parseInt(Files.toString(aHeadFile, Charsets.UTF_8)));
@@ -119,7 +119,7 @@ public class ProtegeOntologyState implements OntologyState {
 	}
 
 	private void writeRevision() throws IOException {
-		final File aHeadFile = revisionFile(path);
+		final File aHeadFile = revisionFile();
 		Files.write(String.valueOf(getVersion()), aHeadFile, Charsets.UTF_8);
 	}
 

--- a/server/src/main/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerState.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerState.java
@@ -9,15 +9,9 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import edu.stanford.protege.metaproject.ConfigurationManager;
-import edu.stanford.protege.metaproject.api.PlainPassword;
-import edu.stanford.protege.metaproject.api.PolicyFactory;
 import edu.stanford.protege.metaproject.api.ProjectId;
-import edu.stanford.protege.metaproject.api.UserId;
 import edu.stanford.protege.metaproject.impl.ProjectIdImpl;
 import org.protege.editor.owl.client.LocalHttpClient;
-import org.protege.editor.owl.client.api.exception.AuthorizationException;
-import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -44,7 +38,6 @@ public final class ProtegeServerState implements ServerState {
 	protected OWLOntologyManager manager;
 
 	private LocalHttpClient client;
-	LocalHttpClient managerClient;
 
 	/**
 	 * Lock to control reloads of the state
@@ -67,18 +60,6 @@ public final class ProtegeServerState implements ServerState {
 		this.manager = OWLManager.createOWLOntologyManager();
 		this.ontologies = Maps.newConcurrentMap();
 		this.client = ProtegeServiceUtils.connect(theConfigReader);
-
-		PolicyFactory f = ConfigurationManager.getFactory();
-		UserId managerId = f.getUserId("bob");
-		PlainPassword managerPassword = f.getPlainPassword("bob");
-		// TODO this hard coding is incorrect. Should be fixed.
-		try {
-			this.managerClient = new LocalHttpClient(managerId.get(), managerPassword.getPassword(), "http://localhost:8081");
-		} catch (AuthorizationException e) {
-			throw new RuntimeException(e);
-		} catch (ClientRequestException e) {
-			throw new RuntimeException(e);
-		}
 
 		Set<String> onts = theConfigReader.protegeSettings().ontologies();
 		for (String ont : onts) {

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -1,13 +1,19 @@
 package com.clarkparsia.pellet.server.protege.model;
 
+import com.clarkparsia.pellet.server.ConfigurationReader;
 import com.clarkparsia.pellet.server.model.OntologyState;
 import com.clarkparsia.pellet.server.protege.ProtegeServerTest;
 import com.clarkparsia.pellet.server.protege.TestProtegeServerConfiguration;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import edu.stanford.protege.metaproject.ConfigurationManager;
+import edu.stanford.protege.metaproject.api.PlainPassword;
+import edu.stanford.protege.metaproject.api.PolicyFactory;
+import edu.stanford.protege.metaproject.api.UserId;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.protege.editor.owl.client.LocalHttpClient;
 import org.semanticweb.owlapi.model.IRI;
 
 import java.io.IOException;
@@ -32,10 +38,19 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 	@Before
 	public void before() throws Exception {
 		super.before();
-		mServerState = new ProtegeServerState(new TestProtegeServerConfiguration(Lists.<String>newArrayList()));
+		final TestProtegeServerConfiguration pelletConfig = new TestProtegeServerConfiguration(Lists.<String>newArrayList());
+		mServerState = new ProtegeServerState(pelletConfig);
 		assertTrue(mServerState.ontologies().isEmpty());
-		createOwl2Ontology(mServerState.managerClient);
-		createAgenciesOntology(mServerState.managerClient);
+
+		PolicyFactory f = ConfigurationManager.getFactory();
+		UserId managerId = f.getUserId("bob");
+		PlainPassword managerPassword = f.getPlainPassword("bob");
+		LocalHttpClient managerClient = new LocalHttpClient(managerId.get(),
+			managerPassword.getPassword(),
+			ConfigurationReader.of(pelletConfig).protegeSettings().host() + ":8081");
+
+		createOwl2Ontology(managerClient);
+		createAgenciesOntology(managerClient);
 		mServerState.close();
 		mServerState = new ProtegeServerState(new TestProtegeServerConfiguration(ONTOLOGIES));
 	}

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -105,7 +105,7 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 
 	private void assertOntologyFilesExist(ProtegeServerState state) throws IOException {
 		for (OntologyState aState : state.ontologies()) {
-			assertTrue(Files.exists(((ProtegeOntologyState) aState).path.resolveSibling("HEAD")));
+			assertTrue(((ProtegeOntologyState) aState).revisionFile().exists());
 			assertTrue(Files.exists(((ProtegeOntologyState) aState).path));
 		}
 	}


### PR DESCRIPTION
It's only being used in the tests, hence that is where it should live.