### PR TITLE
Add hook for providing project id in the header of every request

### DIFF
--- a/cli/src/main/java/pellet/PelletServer.java
+++ b/cli/src/main/java/pellet/PelletServer.java
@@ -116,7 +116,7 @@ public class PelletServer extends PelletCmdApp {
 			endpoint = pelletSettings.endpoint();
 		}
 
-		Injector aInjector = Guice.createInjector(new ClientModule(endpoint, Optional.of(pelletSettings.managementPassword())));
+		Injector aInjector = Guice.createInjector(new ClientModule(endpoint, Optional.of(pelletSettings.managementPassword()), null));
 
 		Call<Void> shutdownCall = aInjector.getInstance(PelletService.class).shutdown();
 		ClientTools.executeCall(shutdownCall);

--- a/client/src/main/java/com/complexible/pellet/client/ClientModule.java
+++ b/client/src/main/java/com/complexible/pellet/client/ClientModule.java
@@ -10,6 +10,7 @@ import com.google.common.base.Optional;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
+import okhttp3.Interceptor;
 
 import javax.inject.Provider;
 

--- a/client/src/main/java/com/complexible/pellet/client/ClientModule.java
+++ b/client/src/main/java/com/complexible/pellet/client/ClientModule.java
@@ -10,7 +10,6 @@ import com.google.common.base.Optional;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
-import okhttp3.Interceptor;
 
 import javax.inject.Provider;
 

--- a/client/src/main/java/com/complexible/pellet/client/ClientModule.java
+++ b/client/src/main/java/com/complexible/pellet/client/ClientModule.java
@@ -10,7 +10,9 @@ import com.google.common.base.Optional;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
+import okhttp3.Interceptor;
 
+import javax.inject.Provider;
 
 
 /**
@@ -18,26 +20,27 @@ import com.google.inject.name.Names;
  */
 public class ClientModule extends AbstractModule {
 
-	private final String mEndpoint;
+	public static final int TIMEOUT_MIN = 3;
+	private final String endpoint;
 
-	private final long mConnTimeoutMin;
+	private final long connTimeoutMin;
 
-	private final long mReadTimeoutMin;
+	private final long readTimeoutMin;
 
-	private final long mWriteTimeoutMin;
+	private final long writeTimeoutMin;
 	private final Optional<String> managementPassword;
+	// Should really be Provider<ProjectId> but we don't have the correct dependency on hand
+	private final Provider<String> projectIdProvider;
 
-	public ClientModule(final String theEndpoint, final long theConnTimeoutMin, final long theReadTimeoutMin,
-											final long theWriteTimeoutMin, final Optional<String> managementPassword) {
-		mEndpoint = theEndpoint;
-		mConnTimeoutMin = theConnTimeoutMin;
-		mReadTimeoutMin = theReadTimeoutMin;
-		mWriteTimeoutMin = theWriteTimeoutMin;
+	public ClientModule(final String endpoint,
+											final Optional<String> managementPassword,
+											final Provider<String> projectIdProvider) {
+		this.endpoint = endpoint;
+		this.connTimeoutMin = TIMEOUT_MIN;
+		this.readTimeoutMin = TIMEOUT_MIN;
+		this.writeTimeoutMin = TIMEOUT_MIN;
 		this.managementPassword = managementPassword;
-	}
-
-	public ClientModule(final String theEndpoint, final Optional<String> managementPassword) {
-		this(theEndpoint, 3, 3, 3, managementPassword);
+		this.projectIdProvider = projectIdProvider;
 	}
 
 	@Override
@@ -47,16 +50,19 @@ public class ClientModule extends AbstractModule {
 			        .build(SchemaReasonerFactory.class));
 
 		bind(String.class).annotatedWith(Names.named("endpoint"))
-		                  .toInstance(mEndpoint);
+		                  .toInstance(endpoint);
 		bind(Long.class).annotatedWith(Names.named("conn_timeout"))
-		                   .toInstance(mConnTimeoutMin);
+		                   .toInstance(connTimeoutMin);
 		bind(Long.class).annotatedWith(Names.named("read_timeout"))
-		                   .toInstance(mReadTimeoutMin);
+		                   .toInstance(readTimeoutMin);
 		bind(Long.class).annotatedWith(Names.named("write_timeout"))
-		                   .toInstance(mWriteTimeoutMin);
+		                   .toInstance(writeTimeoutMin);
 		bind(new TypeLiteral<Optional<String>>(){ }).annotatedWith(Names.named("management_password"))
 			.toInstance(managementPassword);
 
+		bind(new TypeLiteral<Provider<String>>() {})
+			.annotatedWith(Names.named("project_id_provider"))
+			.toInstance(projectIdProvider);
 		bind(PelletService.class).toProvider(PelletServiceProvider.class).in(Singleton.class);
 	}
 }

--- a/client/src/main/java/com/complexible/pellet/client/PelletService.java
+++ b/client/src/main/java/com/complexible/pellet/client/PelletService.java
@@ -2,6 +2,7 @@ package com.complexible.pellet.client;
 
 import java.util.UUID;
 
+import com.clarkparsia.pellet.service.PelletServiceConstants;
 import com.clarkparsia.pellet.service.reasoner.SchemaQuery;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
@@ -31,38 +32,38 @@ public interface PelletService {
 	@GET("/admin/restart")
 	Call<Void> restart();
 
-	@POST("/reasoner/{ontology}/query")
-	Call<NodeSet> query(@Path("ontology") IRI theOntology,
-	                    @Query("client") UUID theClientID,
-	                    @Body SchemaQuery query);
+	@POST("/reasoner/query")
+	Call<NodeSet> query(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+											@Query("client") UUID theClientID,
+											@Body SchemaQuery query);
 
-	@POST("/reasoner/{ontology}/explain")
-	Call<OWLOntology> explain(@Path("ontology") IRI theOntology,
-	                           @Query("client") UUID theClientID,
-	                           @Query("limit") int limit,
-	                           @Body OWLAxiom inference);
+	@POST("/reasoner/explain")
+	Call<OWLOntology> explain(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+														@Query("client") UUID theClientID,
+														@Query("limit") int limit,
+														@Body OWLAxiom inference);
 
-	@POST("/reasoner/{ontology}/insert")
-	Call<Void> insert(@Path("ontology") IRI theOntology,
-	                  @Query("client") UUID theClientID,
-	                  @Body OWLOntology axioms);
+	@POST("/reasoner/insert")
+	Call<Void> insert(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+										@Query("client") UUID theClientID,
+										@Body OWLOntology axioms);
 
-	@POST("/reasoner/{ontology}/delete")
-	Call<Void> delete(@Path("ontology") IRI theOntology,
-	                  @Query("client") UUID theClientID,
-	                  @Body OWLOntology axioms);
+	@POST("/reasoner/delete")
+	Call<Void> delete(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+										@Query("client") UUID theClientID,
+										@Body OWLOntology axioms);
 
-	@GET("/reasoner/{ontology}/classify")
-	Call<Void> classify(@Path("ontology") IRI theOntology,
-	                    @Query("client") UUID theClientID);
+	@GET("/reasoner/classify")
+	Call<Void> classify(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+											@Query("client") UUID theClientID);
 
-	@GET("/reasoner/{ontology}/version")
-	Call<Integer> version(@Path("ontology") IRI theOntology,
-	                      @Query("client") UUID theClientID);
+	@GET("/reasoner/version")
+	Call<Integer> version(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology,
+												@Query("client") UUID theClientID);
 
-	@PUT("/reasoner/{ontology}")
-	Call<Void> load(@Path("ontology") String theOntologyPath);
+	@PUT("/reasoner")
+	Call<Void> load(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntologyPath);
 
-	@DELETE("/reasoner/{ontology}")
-	Call<Void> unload(@Path("ontology") IRI theOntology);
+	@DELETE("/reasoner")
+	Call<Void> unload(@Query(PelletServiceConstants.ONTOLOGY) IRI theOntology);
 }

--- a/client/src/main/java/com/complexible/pellet/client/PelletServiceProvider.java
+++ b/client/src/main/java/com/complexible/pellet/client/PelletServiceProvider.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.clarkparsia.owlapiv3.OWL;
+import com.clarkparsia.pellet.service.PelletServiceConstants;
 import com.clarkparsia.pellet.service.messages.JsonMessage;
 import com.clarkparsia.pellet.service.reasoner.SchemaQuery;
 import com.google.common.base.Optional;
@@ -33,7 +34,6 @@ import retrofit2.Retrofit;
  */
 public class PelletServiceProvider implements Provider<PelletService> {
 
-	public static final String PROJECT_ID_HEADER = "X-projectId";
 	private final String endpoint;
 
 	private final long connTimeoutMin;
@@ -73,7 +73,7 @@ public class PelletServiceProvider implements Provider<PelletService> {
 		httpClientBuilder.interceptors().add(new Interceptor() {
 			@Override
 			public Response intercept(Chain chain) throws IOException {
-				final Request request = chain.request().newBuilder().addHeader(PROJECT_ID_HEADER, projectIdProvider.get()).build();
+				final Request request = chain.request().newBuilder().addHeader(PelletServiceConstants.PROJECT_ID_HEADER, projectIdProvider.get()).build();
 				return chain.proceed(request);
 			}
 		});

--- a/client/src/main/java/com/complexible/pellet/client/PelletServiceProvider.java
+++ b/client/src/main/java/com/complexible/pellet/client/PelletServiceProvider.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.clarkparsia.owlapiv3.OWL;
-import com.clarkparsia.pellet.service.PelletServiceConstants;
 import com.clarkparsia.pellet.service.messages.JsonMessage;
 import com.clarkparsia.pellet.service.reasoner.SchemaQuery;
 import com.google.common.base.Optional;
@@ -34,6 +33,7 @@ import retrofit2.Retrofit;
  */
 public class PelletServiceProvider implements Provider<PelletService> {
 
+	public static final String PROJECT_ID_HEADER = "X-projectId";
 	private final String endpoint;
 
 	private final long connTimeoutMin;
@@ -73,7 +73,7 @@ public class PelletServiceProvider implements Provider<PelletService> {
 		httpClientBuilder.interceptors().add(new Interceptor() {
 			@Override
 			public Response intercept(Chain chain) throws IOException {
-				final Request request = chain.request().newBuilder().addHeader(PelletServiceConstants.PROJECT_ID_HEADER, projectIdProvider.get()).build();
+				final Request request = chain.request().newBuilder().addHeader(PROJECT_ID_HEADER, projectIdProvider.get()).build();
 				return chain.proceed(request);
 			}
 		});

--- a/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
+++ b/client/src/test/java/com/complexible/pellet/client/PelletClientTest.java
@@ -7,6 +7,7 @@ import com.clarkparsia.pellet.server.protege.ProtegeServerTest;
 import com.clarkparsia.pellet.server.protege.TestUtilities;
 import com.google.common.base.Optional;
 import com.google.inject.Guice;
+import com.google.inject.Provider;
 import com.google.inject.util.Modules;
 import edu.stanford.protege.metaproject.ConfigurationManager;
 import edu.stanford.protege.metaproject.api.PlainPassword;
@@ -27,7 +28,13 @@ public abstract class PelletClientTest extends ProtegeServerTest {
 	protected static PelletServer pelletServer;
 	protected PelletServiceProvider serviceProvider =
 		new PelletServiceProvider(PelletService.DEFAULT_LOCAL_ENDPOINT,
-			0, 0, 0, Optional.of(TestUtilities.PELLET_MANAGEMENT_PASSWORD));
+			0, 0, 0, Optional.of(TestUtilities.PELLET_MANAGEMENT_PASSWORD),
+			new Provider<String>() {
+				@Override
+				public String get() {
+					return "dummyProjectId";
+				}
+			});
 
 	protected LocalHttpClient client;
 	LocalHttpClient managerClient;

--- a/client/src/test/java/com/complexible/pellet/client/PelletServiceTest.java
+++ b/client/src/test/java/com/complexible/pellet/client/PelletServiceTest.java
@@ -1,6 +1,7 @@
 package com.complexible.pellet.client;
 
 import com.clarkparsia.owlapiv3.OWL;
+import com.clarkparsia.pellet.server.protege.model.ProjectIRI;
 import com.google.common.collect.Lists;
 import edu.stanford.protege.metaproject.ConfigurationManager;
 import org.junit.Before;
@@ -11,7 +12,6 @@ import org.protege.editor.owl.server.policy.CommitBundleImpl;
 import org.protege.editor.owl.server.versioning.Commit;
 import org.protege.editor.owl.server.versioning.api.DocumentRevision;
 import org.semanticweb.owlapi.model.AddAxiom;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import retrofit2.Call;
@@ -28,16 +28,16 @@ import static org.junit.Assert.assertEquals;
 public class PelletServiceTest extends PelletClientTest {
 	private UUID ID = UUID.randomUUID();
 
-	private IRI agencyOntId;
-	private IRI owl2OntId;
+	private ProjectIRI agency;
+	private ProjectIRI owl;
 
 	@Before
 	public void before() throws Exception {
 		super.before();
 
 		// create test ontology
-		agencyOntId = createAgenciesOntology(managerClient);
-		owl2OntId = createOwl2Ontology(managerClient);
+		agency = createAgenciesOntology(managerClient);
+		owl = createOwl2Ontology(managerClient);
 
 		startPelletServer(Lists.newArrayList(AGENCIES_ONT));
 	}
@@ -46,28 +46,28 @@ public class PelletServiceTest extends PelletClientTest {
 	public void shouldUpdateWithEmptySets() throws Exception {
 		PelletService aService = serviceProvider.get();
 
-		ClientTools.executeCall(aService.insert(agencyOntId, ID, OWL.Ontology()));
-		ClientTools.executeCall(aService.delete(agencyOntId, ID, OWL.Ontology()));
+		ClientTools.executeCall(aService.insert(agency.projectIRI(), ID, OWL.Ontology()));
+		ClientTools.executeCall(aService.delete(agency.projectIRI(), ID, OWL.Ontology()));
 	}
 
 	@Test
 	public void shouldGetVersionFromClient() throws Exception {
 		PelletService aService = serviceProvider.get();
 
-		Call<Integer> aVersionCall = aService.version(agencyOntId, ID);
+		Call<Integer> aVersionCall = aService.version(agency.projectIRI(), ID);
 
 		int aVersion = ClientTools.executeCall(aVersionCall);
 
 		assertEquals(0, aVersion);
 
-		OWLOntology ont = OWL.manager.createOntology(agencyOntId);
+		OWLOntology ont = OWL.manager.createOntology(agency.projectIRI());
 		Commit commit = ClientUtils.createCommit(client, "comment", Arrays.<OWLOntologyChange>asList(new AddAxiom(ont, OWL.subClassOf(OWL.Nothing, OWL.Thing))));
 		CommitBundle commitBundle = new CommitBundleImpl(DocumentRevision.START_REVISION, commit);
 		client.commit(ConfigurationManager.getFactory().getProjectId(AGENCIES_ONT), commitBundle);
 
 		pelletServer.getState().update();
 
-		aVersionCall = aService.version(agencyOntId, UUID.randomUUID());
+		aVersionCall = aService.version(agency.projectIRI(), UUID.randomUUID());
 
 		aVersion = ClientTools.executeCall(aVersionCall);
 
@@ -77,9 +77,9 @@ public class PelletServiceTest extends PelletClientTest {
 	@Test
 	public void restartPellet() {
 		PelletService aService = serviceProvider.get();
-		Integer v1 = ClientTools.executeCall(aService.version(agencyOntId, ID));
+		Integer v1 = ClientTools.executeCall(aService.version(agency.projectIRI(), ID));
 		ClientTools.executeCall(serviceProvider.get().restart());
-		Integer v2 = ClientTools.executeCall(aService.version(agencyOntId, ID));
+		Integer v2 = ClientTools.executeCall(aService.version(agency.projectIRI(), ID));
 		assertEquals(v1, v2);
 	}
 
@@ -87,12 +87,12 @@ public class PelletServiceTest extends PelletClientTest {
 	public void ontologyAddDelete() throws Exception {
 		PelletService aService = serviceProvider.get();
 
-		ClientTools.executeCall(aService.load(OWL2_ONT));
+		ClientTools.executeCall(aService.load(agency.projectIRI()));
 
-		ClientTools.executeCall(aService.unload(owl2OntId));
+		ClientTools.executeCall(aService.unload(owl.projectIRI()));
 
-		Response<Void> aResp = aService.unload(owl2OntId).execute();
+		Response<Void> aResp = aService.unload(owl.projectIRI()).execute();
 		assertEquals(400, aResp.code());
-		assertEquals("Ontology not found: " + owl2OntId, aResp.message());
+		assertEquals("Ontology not found: " + owl.projectIRI(), aResp.message());
 	}
 }

--- a/owlapi/pom.xml
+++ b/owlapi/pom.xml
@@ -26,6 +26,11 @@
 			<version>${owlapi.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>3.6.0</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/owlapi/src/main/java/com/clarkparsia/owlapiv3/IRIUtils.java
+++ b/owlapi/src/main/java/com/clarkparsia/owlapiv3/IRIUtils.java
@@ -1,0 +1,16 @@
+package com.clarkparsia.owlapiv3;
+
+import okhttp3.HttpUrl;
+import org.semanticweb.owlapi.model.IRI;
+
+/**
+ * Created by rgrinberg on 7/25/17.
+ */
+public class IRIUtils {
+	public static final String PROJECT_ID = "projectId";
+
+	public static IRI addProjectId(IRI iri, String projectId) {
+		HttpUrl url = HttpUrl.parse(iri.toString()).newBuilder().addQueryParameter(PROJECT_ID, projectId).build();
+		return IRI.create(url.uri());
+	}
+}

--- a/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerFactory.java
+++ b/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerFactory.java
@@ -46,7 +46,7 @@ public class PelletReasonerFactory extends AbstractProtegeOWLReasonerInfo {
 			case REMOTE: {
 				final String serverURL = PelletReasonerPreferences.getInstance().getServerURL();
 				// TODO: read timeout from preferences too and pass to ClientModule, 3 min by default
-				final Injector aInjector = Guice.createInjector(new ClientModule(serverURL, Optional.<String>absent()));
+				final Injector aInjector = Guice.createInjector(new ClientModule(serverURL, Optional.<String>absent(), null));
 				factory = new RemotePelletReasonerFactory(aInjector.getInstance(SchemaReasonerFactory.class), getOWLModelManager());
 				break;
 			}

--- a/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerPreferences.java
+++ b/protege/src/main/java/com/clarkparsia/pellet/protege/PelletReasonerPreferences.java
@@ -29,32 +29,24 @@ public class PelletReasonerPreferences {
     private boolean updated = false;
 
     private PelletReasonerPreferences() {
-        _load();
-    }
+			reasonerMode = PelletReasonerMode.valueOf(prefs.getString("reasonerMode", PelletReasonerMode.REGULAR.name()));
+			serverURL = prefs.getString("serverURL", "http://localhost:18080");
+			explanationCount = prefs.getInt("explanationCount", 0);
+		}
 
-    private void _load() {
-        reasonerMode = PelletReasonerMode.valueOf(prefs.getString("reasonerMode", PelletReasonerMode.REGULAR.name()));
-        serverURL = prefs.getString("serverURL", "http://localhost:18080");
-        explanationCount = prefs.getInt("explanationCount", 0);
-    }
+	public boolean save() {
+		if (!updated) {
+			return false;
+		}
 
-    private void _save() {
-        prefs.putString("reasonerMode", reasonerMode.name());
-        prefs.putString("serverURL", serverURL);
-        prefs.putInt("explanationCount", explanationCount);
-    }
+		updated = false;
 
-    public boolean save() {
-        if (!updated) {
-            return false;
-        }
+		prefs.putString("reasonerMode", reasonerMode.name());
+		prefs.putString("serverURL", serverURL);
+		prefs.putInt("explanationCount", explanationCount);
 
-        updated = false;
-
-        _save();
-
-        return true;
-    }
+		return true;
+	}
 
     private void update(Object oldValue, Object newValue) {
         if (!Objects.equals(oldValue, newValue)) {

--- a/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
@@ -73,7 +73,6 @@ public final class PelletServer {
 			router.add(spec.getMethod(), spec.getPath(), aHandler);
 		}
 
-		final Properties propreties = serverInjector.getInstance(Properties.class);
 		PelletSettings pelletSettings = serverInjector.getInstance(PelletSettings.class);
 		String managementPassword = pelletSettings.managementPassword();
 		// add shutdown path

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -6,6 +6,7 @@ import com.clarkparsia.pellet.server.exceptions.ServerException;
 import com.clarkparsia.pellet.server.protege.ClientState;
 import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.clarkparsia.pellet.service.PelletServiceConstants;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import edu.stanford.protege.metaproject.api.ProjectId;
@@ -73,12 +74,12 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 	}
 
 	protected static ProjectId getProjectId(final HttpServerExchange exchange) throws ServerException {
-		try {
-			return new ProjectIdImpl(exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
-				.getParameters().get("projectId"));
-		}
-		catch (Exception e) {
-			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Ontology IRI", e);
+		final String projectId = exchange.getRequestHeaders().getFirst(PelletServiceConstants.PROJECT_ID_HEADER);
+		if (projectId == null) {
+			throw new ServerException(StatusCodes.BAD_REQUEST,
+				"Header " + PelletServiceConstants.PROJECT_ID_HEADER + " doesn't exist");
+		} else {
+			return new ProjectIdImpl(projectId);
 		}
 	}
 

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -1,5 +1,6 @@
 package com.clarkparsia.pellet.server.handlers;
 
+import com.clarkparsia.owlapiv3.IRIUtils;
 import com.clarkparsia.owlapiv3.OWL;
 import com.clarkparsia.pellet.server.PelletServer;
 import com.clarkparsia.pellet.server.exceptions.ServerException;
@@ -12,13 +13,13 @@ import com.google.common.base.Strings;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
+import okhttp3.HttpUrl;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.vocab.Namespaces;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -82,9 +83,9 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 				throw new ServerException(StatusCodes.BAD_REQUEST, "Header "
 					+ PelletServiceConstants.PROJECT_ID_HEADER + " not provided");
 			}
-			final String ontology = URLDecoder.decode(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
-				.getParameters().get("ontology"), StandardCharsets.UTF_8.name()) + "?projectId=" + projectId;
-			return IRI.create(ontology);
+			final IRI iri = IRI.create(URLDecoder.decode(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
+				.getParameters().get("ontology"), StandardCharsets.UTF_8.name()));
+			return IRIUtils.addProjectId(iri, projectId);
 		}
 		catch (Exception theE) {
 			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Ontology IRI", theE);

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -1,13 +1,13 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.owlapiv3.OWL;
 import com.clarkparsia.pellet.server.PelletServer;
 import com.clarkparsia.pellet.server.exceptions.ServerException;
 import com.clarkparsia.pellet.server.protege.ClientState;
+import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.google.common.base.Strings;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -1,18 +1,19 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.owlapiv3.OWL;
 import com.clarkparsia.pellet.server.PelletServer;
 import com.clarkparsia.pellet.server.exceptions.ServerException;
 import com.clarkparsia.pellet.server.protege.ClientState;
+import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.google.common.base.Strings;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import edu.stanford.protege.metaproject.api.ProjectId;
+import edu.stanford.protege.metaproject.impl.ProjectIdImpl;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -20,8 +21,6 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
@@ -64,22 +63,22 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		return serverState;
 	}
 
-	protected ClientState getClientState(final IRI theOntology, final UUID theClientId) throws ServerException {
-		Optional<ProtegeOntologyState> aOntoState = getServerState().getOntology(theOntology);
+	protected ClientState getClientState(ProjectId projectId, final UUID theClientId) throws ServerException {
+		Optional<ProtegeOntologyState> aOntoState = getServerState().getOntology(projectId);
 		if (!aOntoState.isPresent()) {
-			throw new ServerException(StatusCodes.NOT_FOUND, "Ontology not found: " + theOntology);
+			throw new ServerException(StatusCodes.NOT_FOUND, "Project not found: " + projectId);
 		}
 
 		return aOntoState.get().getClient(theClientId);
 	}
 
-	protected static IRI getOntology(final HttpServerExchange theExchange) throws ServerException {
+	protected static ProjectId getProjectId(final HttpServerExchange theExchange) throws ServerException {
 		try {
-			return IRI.create(URLDecoder.decode(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
-					.getParameters().get("ontology"), StandardCharsets.UTF_8.name()));
+			return new ProjectIdImpl(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
+				.getParameters().get("projectId"));
 		}
-		catch (Exception theE) {
-			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Ontology IRI", theE);
+		catch (Exception e) {
+			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Ontology IRI", e);
 		}
 	}
 

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -6,7 +6,6 @@ import com.clarkparsia.pellet.server.exceptions.ServerException;
 import com.clarkparsia.pellet.server.protege.ClientState;
 import com.clarkparsia.pellet.server.protege.ProtegeOntologyState;
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.clarkparsia.pellet.service.PelletServiceConstants;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import edu.stanford.protege.metaproject.api.ProjectId;
@@ -74,12 +73,12 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 	}
 
 	protected static ProjectId getProjectId(final HttpServerExchange exchange) throws ServerException {
-		final String projectId = exchange.getRequestHeaders().getFirst(PelletServiceConstants.PROJECT_ID_HEADER);
-		if (projectId == null) {
-			throw new ServerException(StatusCodes.BAD_REQUEST,
-				"Header " + PelletServiceConstants.PROJECT_ID_HEADER + " doesn't exist");
-		} else {
-			return new ProjectIdImpl(projectId);
+		try {
+			return new ProjectIdImpl(exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
+				.getParameters().get("projectId"));
+		}
+		catch (Exception e) {
+			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Ontology IRI", e);
 		}
 	}
 

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -34,28 +34,28 @@ import java.util.UUID;
 public abstract class AbstractRoutingHandler implements RoutingHandler {
 	public static String REASONER_PATH = PelletServer.ROOT_PATH + "reasoner";
 
-	private final String path;
-	private final String method;
+	private final String mPath;
+	private final String mMethod;
 	private final ProtegeServerState serverState;
 
 	protected final OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
 
-	public AbstractRoutingHandler(final String method,
-	                              final String path,
-	                              final ProtegeServerState serverState) {
-		this.serverState = serverState;
-		this.method = method;
-		this.path = REASONER_PATH + "/" + path;
+	public AbstractRoutingHandler(final String theMethod,
+	                              final String thePath,
+	                              final ProtegeServerState theServerState) {
+		serverState = theServerState;
+		mMethod = theMethod;
+		mPath = REASONER_PATH + "/" + thePath;
 	}
 
 	@Override
 	public final String getMethod() {
-		return method;
+		return mMethod;
 	}
 
 	@Override
 	public final String getPath() {
-		return path;
+		return mPath;
 	}
 
 
@@ -63,18 +63,18 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		return serverState;
 	}
 
-	protected ClientState getClientState(ProjectId projectId, final UUID clientId) throws ServerException {
+	protected ClientState getClientState(ProjectId projectId, final UUID theClientId) throws ServerException {
 		Optional<ProtegeOntologyState> aOntoState = getServerState().getOntology(projectId);
 		if (!aOntoState.isPresent()) {
 			throw new ServerException(StatusCodes.NOT_FOUND, "Project not found: " + projectId);
 		}
 
-		return aOntoState.get().getClient(clientId);
+		return aOntoState.get().getClient(theClientId);
 	}
 
-	protected static ProjectId getProjectId(final HttpServerExchange exchange) throws ServerException {
+	protected static ProjectId getProjectId(final HttpServerExchange theExchange) throws ServerException {
 		try {
-			return new ProjectIdImpl(exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
+			return new ProjectIdImpl(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
 				.getParameters().get("projectId"));
 		}
 		catch (Exception e) {
@@ -82,18 +82,18 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		}
 	}
 
-	protected static UUID getClientID(final HttpServerExchange exchange) throws ServerException {
+	protected static UUID getClientID(final HttpServerExchange theExchange) throws ServerException {
 		try {
-			return UUID.fromString(getQueryParameter(exchange, "client"));
+			return UUID.fromString(getQueryParameter(theExchange, "client"));
 		}
-		catch (IllegalArgumentException e) {
-			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Client ID - must be a UUID", e);
+		catch (IllegalArgumentException theE) {
+			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Client ID - must be a UUID", theE);
 		}
 	}
 
-	protected static String getQueryParameter(final HttpServerExchange exchange,
+	protected static String getQueryParameter(final HttpServerExchange theExchange,
 																						final String paramName) throws ServerException {
-		final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+		final Map<String, Deque<String>> queryParams = theExchange.getQueryParameters();
 
 		if (!queryParams.containsKey(paramName) || queryParams.get(paramName).isEmpty()) {
 			throw new ServerException(StatusCodes.BAD_REQUEST, "Missing required parameter: "+ paramName);
@@ -108,10 +108,10 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 	}
 
 
-	protected Set<OWLAxiom> readAxioms(final InputStream inputStream) throws ServerException {
+	protected Set<OWLAxiom> readAxioms(final InputStream theInStream) throws ServerException {
 		OWLOntology ontology = null;
 		try {
-			ontology = manager.loadOntologyFromOntologyDocument(inputStream);
+			ontology = manager.loadOntologyFromOntologyDocument(theInStream);
 
 			return ontology.getAxioms();
 		}
@@ -123,7 +123,7 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		}
 		finally {
 			try {
-				inputStream.close();
+				theInStream.close();
 			}
 			catch (IOException e) {
 				e.printStackTrace();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/AbstractRoutingHandler.java
@@ -34,28 +34,28 @@ import java.util.UUID;
 public abstract class AbstractRoutingHandler implements RoutingHandler {
 	public static String REASONER_PATH = PelletServer.ROOT_PATH + "reasoner";
 
-	private final String mPath;
-	private final String mMethod;
+	private final String path;
+	private final String method;
 	private final ProtegeServerState serverState;
 
 	protected final OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
 
-	public AbstractRoutingHandler(final String theMethod,
-	                              final String thePath,
-	                              final ProtegeServerState theServerState) {
-		serverState = theServerState;
-		mMethod = theMethod;
-		mPath = REASONER_PATH + "/" + thePath;
+	public AbstractRoutingHandler(final String method,
+	                              final String path,
+	                              final ProtegeServerState serverState) {
+		this.serverState = serverState;
+		this.method = method;
+		this.path = REASONER_PATH + "/" + path;
 	}
 
 	@Override
 	public final String getMethod() {
-		return mMethod;
+		return method;
 	}
 
 	@Override
 	public final String getPath() {
-		return mPath;
+		return path;
 	}
 
 
@@ -63,18 +63,18 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		return serverState;
 	}
 
-	protected ClientState getClientState(ProjectId projectId, final UUID theClientId) throws ServerException {
+	protected ClientState getClientState(ProjectId projectId, final UUID clientId) throws ServerException {
 		Optional<ProtegeOntologyState> aOntoState = getServerState().getOntology(projectId);
 		if (!aOntoState.isPresent()) {
 			throw new ServerException(StatusCodes.NOT_FOUND, "Project not found: " + projectId);
 		}
 
-		return aOntoState.get().getClient(theClientId);
+		return aOntoState.get().getClient(clientId);
 	}
 
-	protected static ProjectId getProjectId(final HttpServerExchange theExchange) throws ServerException {
+	protected static ProjectId getProjectId(final HttpServerExchange exchange) throws ServerException {
 		try {
-			return new ProjectIdImpl(theExchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
+			return new ProjectIdImpl(exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY)
 				.getParameters().get("projectId"));
 		}
 		catch (Exception e) {
@@ -82,18 +82,18 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		}
 	}
 
-	protected static UUID getClientID(final HttpServerExchange theExchange) throws ServerException {
+	protected static UUID getClientID(final HttpServerExchange exchange) throws ServerException {
 		try {
-			return UUID.fromString(getQueryParameter(theExchange, "client"));
+			return UUID.fromString(getQueryParameter(exchange, "client"));
 		}
-		catch (IllegalArgumentException theE) {
-			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Client ID - must be a UUID", theE);
+		catch (IllegalArgumentException e) {
+			throw new ServerException(StatusCodes.BAD_REQUEST, "Error parsing Client ID - must be a UUID", e);
 		}
 	}
 
-	protected static String getQueryParameter(final HttpServerExchange theExchange,
+	protected static String getQueryParameter(final HttpServerExchange exchange,
 																						final String paramName) throws ServerException {
-		final Map<String, Deque<String>> queryParams = theExchange.getQueryParameters();
+		final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
 
 		if (!queryParams.containsKey(paramName) || queryParams.get(paramName).isEmpty()) {
 			throw new ServerException(StatusCodes.BAD_REQUEST, "Missing required parameter: "+ paramName);
@@ -108,10 +108,10 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 	}
 
 
-	protected Set<OWLAxiom> readAxioms(final InputStream theInStream) throws ServerException {
+	protected Set<OWLAxiom> readAxioms(final InputStream inputStream) throws ServerException {
 		OWLOntology ontology = null;
 		try {
-			ontology = manager.loadOntologyFromOntologyDocument(theInStream);
+			ontology = manager.loadOntologyFromOntologyDocument(inputStream);
 
 			return ontology.getAxioms();
 		}
@@ -123,7 +123,7 @@ public abstract class AbstractRoutingHandler implements RoutingHandler {
 		}
 		finally {
 			try {
-				theInStream.close();
+				inputStream.close();
 			}
 			catch (IOException e) {
 				e.printStackTrace();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
@@ -20,7 +20,7 @@ public class OntologyAddHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		getServerState().addOntology(getProjectId(theExchange).toString());
+		getServerState().addOntology(getOntology(theExchange).toString());
 
 		theExchange.setStatusCode(StatusCodes.OK);
 		theExchange.endExchange();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
@@ -20,7 +20,7 @@ public class OntologyAddHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		getServerState().addOntology(getOntology(theExchange).toString());
+		getServerState().addOntology(getProjectId(theExchange).toString());
 
 		theExchange.setStatusCode(StatusCodes.OK);
 		theExchange.endExchange();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyAddHandler.java
@@ -12,7 +12,7 @@ public class OntologyAddHandler extends AbstractRoutingHandler {
 
 	@Inject
 	public OntologyAddHandler(final ProtegeServerState theServerState) {
-		super("PUT", "{ontology}", theServerState);
+		super("PUT", "", theServerState);
 	}
 
 	/**

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
@@ -2,11 +2,9 @@ package com.clarkparsia.pellet.server.handlers;
 
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
 import com.google.inject.Inject;
-import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
-
-import static io.undertow.util.StatusCodes.BAD_REQUEST;
-import static io.undertow.util.StatusCodes.OK;
+import io.undertow.util.StatusCodes;
+import org.semanticweb.owlapi.model.IRI;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -23,14 +21,15 @@ public class OntologyRemoveHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		ProjectId projectId = getProjectId(theExchange);
-		boolean removed = getServerState().removeProject(projectId);
+		IRI ont = getOntology(theExchange);
+		boolean removed = getServerState().removeOntology(ont);
 
 		if (removed) {
-			theExchange.setStatusCode(OK);
-		} else {
-			theExchange.setStatusCode(BAD_REQUEST);
-			theExchange.setReasonPhrase("Ontology not found: " + projectId);
+			theExchange.setStatusCode(StatusCodes.OK);
+		}
+		else {
+			theExchange.setStatusCode(StatusCodes.BAD_REQUEST);
+			theExchange.setReasonPhrase("Ontology not found: " + ont);
 		}
 		theExchange.endExchange();
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
@@ -2,9 +2,11 @@ package com.clarkparsia.pellet.server.handlers;
 
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
 import com.google.inject.Inject;
+import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.StatusCodes;
-import org.semanticweb.owlapi.model.IRI;
+
+import static io.undertow.util.StatusCodes.BAD_REQUEST;
+import static io.undertow.util.StatusCodes.OK;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -21,15 +23,14 @@ public class OntologyRemoveHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		IRI ont = getOntology(theExchange);
-		boolean removed = getServerState().removeOntology(ont);
+		ProjectId projectId = getProjectId(theExchange);
+		boolean removed = getServerState().removeProject(projectId);
 
 		if (removed) {
-			theExchange.setStatusCode(StatusCodes.OK);
-		}
-		else {
-			theExchange.setStatusCode(StatusCodes.BAD_REQUEST);
-			theExchange.setReasonPhrase("Ontology not found: " + ont);
+			theExchange.setStatusCode(OK);
+		} else {
+			theExchange.setStatusCode(BAD_REQUEST);
+			theExchange.setReasonPhrase("Ontology not found: " + projectId);
 		}
 		theExchange.endExchange();
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/OntologyRemoveHandler.java
@@ -13,7 +13,7 @@ public class OntologyRemoveHandler extends AbstractRoutingHandler {
 
 	@Inject
 	public OntologyRemoveHandler(final ProtegeServerState theServerState) {
-		super("DELETE", "{ontology}", theServerState);
+		super("DELETE", "", theServerState);
 	}
 
 	/**

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
 import com.google.inject.Inject;
+import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import org.semanticweb.owlapi.model.IRI;
@@ -23,11 +24,11 @@ public class ReasonerClassifyHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final IRI ontology = getOntology(theExchange);
+		final ProjectId projectId = getProjectId(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
 		// Get local client reasoner's version
-		getClientState(ontology, clientId).getReasoner().classify();
+		getClientState(projectId, clientId).getReasoner().classify();
 
 		theExchange.setStatusCode(StatusCodes.OK);
 		theExchange.endExchange();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
@@ -15,7 +15,7 @@ public class ReasonerClassifyHandler extends AbstractRoutingHandler {
 
 	@Inject
 	public ReasonerClassifyHandler(final ProtegeServerState theServerState) {
-		super("GET", "{ontology}/classify", theServerState);
+		super("GET", "classify", theServerState);
 	}
 
 	/**

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerClassifyHandler.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
 import com.google.inject.Inject;
-import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import org.semanticweb.owlapi.model.IRI;
@@ -24,11 +23,11 @@ public class ReasonerClassifyHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final ProjectId projectId = getProjectId(theExchange);
+		final IRI ontology = getOntology(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
 		// Get local client reasoner's version
-		getClientState(projectId, clientId).getReasoner().classify();
+		getClientState(ontology, clientId).getReasoner().classify();
 
 		theExchange.setStatusCode(StatusCodes.OK);
 		theExchange.endExchange();

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerExplainHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerExplainHandler.java
@@ -35,7 +35,7 @@ public class ReasonerExplainHandler extends AbstractRoutingHandler {
 
 	@Inject
 	public ReasonerExplainHandler(final ProtegeServerState theServerState) {
-		super("POST", "{ontology}/explain", theServerState);
+		super("POST", "explain", theServerState);
 	}
 
 	@Override

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerExplainHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerExplainHandler.java
@@ -1,28 +1,29 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.clarkparsia.owlapi.explanation.io.manchester.ManchesterSyntaxExplanationRenderer;
 import com.clarkparsia.pellet.server.exceptions.ServerException;
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
 import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.logging.Level.INFO;
 
 /**
  * Specification for {@link SchemaReasoner#explain(OWLAxiom, int)} functionality within
@@ -40,17 +41,17 @@ public class ReasonerExplainHandler extends AbstractRoutingHandler {
 
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final IRI ontology = getOntology(theExchange);
+		final ProjectId projectId = getProjectId(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
 		int limit = getLimit(theExchange);
 
 		OWLAxiom inference = readAxiom(theExchange.getInputStream());
 
-		final SchemaReasoner aReasoner = getClientState(ontology, clientId).getReasoner();
+		final SchemaReasoner aReasoner = getClientState(projectId, clientId).getReasoner();
 		final Set<Set<OWLAxiom>> explanations = aReasoner.explain(inference, limit);
 
-		if (LOGGER.isLoggable(Level.INFO)) {
+		if (LOGGER.isLoggable(INFO)) {
 			StringWriter sw = new StringWriter();
 			ManchesterSyntaxExplanationRenderer renderer = new ManchesterSyntaxExplanationRenderer();
 			renderer.startRendering(sw);
@@ -60,12 +61,12 @@ public class ReasonerExplainHandler extends AbstractRoutingHandler {
 		}
 
 		OWLDataFactory factory = manager.getOWLDataFactory();
-		Set<OWLAxiom> axioms = Sets.newHashSet();
+		Set<OWLAxiom> axioms = newHashSet();
 		int i = 1;
 		for (Set<OWLAxiom> explanation : explanations) {
 			OWLAnnotation annotation = factory.getOWLAnnotation(factory.getRDFSLabel(), factory.getOWLLiteral("explanation" + (i++)));
 			for (OWLAxiom axiom : explanation) {
-				axioms.add(axiom.getAnnotatedAxiom(ImmutableSet.of(annotation)));
+				axioms.add(axiom.getAnnotatedAxiom(of(annotation)));
 			}
 		}
 

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
@@ -21,7 +21,7 @@ import org.semanticweb.owlapi.reasoner.NodeSet;
 public class ReasonerQueryHandler extends AbstractRoutingHandler {
 	@Inject
 	public ReasonerQueryHandler(final ProtegeServerState theServerState) {
-		super("POST", "{ontology}/query", theServerState);
+		super("POST", "query", theServerState);
 	}
 
 	@Override

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
@@ -1,18 +1,16 @@
 package com.clarkparsia.pellet.server.handlers;
 
+import java.util.UUID;
+
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.clarkparsia.pellet.service.messages.JsonMessage;
 import com.clarkparsia.pellet.service.reasoner.SchemaQuery;
 import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
 import com.google.inject.Inject;
-import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLObject;
 import org.semanticweb.owlapi.reasoner.NodeSet;
-
-import java.util.UUID;
-
-import static com.clarkparsia.pellet.service.messages.JsonMessage.readQuery;
-import static com.clarkparsia.pellet.service.messages.JsonMessage.writeNodeSet;
 
 /**
  * Specification for {@link SchemaReasoner#query(SchemaQuery)} functionality within
@@ -28,13 +26,13 @@ public class ReasonerQueryHandler extends AbstractRoutingHandler {
 
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final ProjectId projectId = getProjectId(theExchange);
+		final IRI ontology = getOntology(theExchange);
 		final UUID clientId = getClientID(theExchange);
-		final SchemaQuery query = readQuery(theExchange.getInputStream());
-		final SchemaReasoner aReasoner = getClientState(projectId, clientId).getReasoner();
+		final SchemaQuery query = JsonMessage.readQuery(theExchange.getInputStream());
+		final SchemaReasoner aReasoner = getClientState(ontology, clientId).getReasoner();
 		final NodeSet<? extends OWLObject> result = aReasoner.query(query);
 
-		writeNodeSet(result, theExchange.getOutputStream());
+		JsonMessage.writeNodeSet(result, theExchange.getOutputStream());
 
 		theExchange.endExchange();
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerQueryHandler.java
@@ -1,16 +1,18 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import java.util.UUID;
-
 import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.clarkparsia.pellet.service.messages.JsonMessage;
 import com.clarkparsia.pellet.service.reasoner.SchemaQuery;
 import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
 import com.google.inject.Inject;
+import edu.stanford.protege.metaproject.api.ProjectId;
 import io.undertow.server.HttpServerExchange;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLObject;
 import org.semanticweb.owlapi.reasoner.NodeSet;
+
+import java.util.UUID;
+
+import static com.clarkparsia.pellet.service.messages.JsonMessage.readQuery;
+import static com.clarkparsia.pellet.service.messages.JsonMessage.writeNodeSet;
 
 /**
  * Specification for {@link SchemaReasoner#query(SchemaQuery)} functionality within
@@ -26,13 +28,13 @@ public class ReasonerQueryHandler extends AbstractRoutingHandler {
 
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final IRI ontology = getOntology(theExchange);
+		final ProjectId projectId = getProjectId(theExchange);
 		final UUID clientId = getClientID(theExchange);
-		final SchemaQuery query = JsonMessage.readQuery(theExchange.getInputStream());
-		final SchemaReasoner aReasoner = getClientState(ontology, clientId).getReasoner();
+		final SchemaQuery query = readQuery(theExchange.getInputStream());
+		final SchemaReasoner aReasoner = getClientState(projectId, clientId).getReasoner();
 		final NodeSet<? extends OWLObject> result = aReasoner.query(query);
 
-		JsonMessage.writeNodeSet(result, theExchange.getOutputStream());
+		writeNodeSet(result, theExchange.getOutputStream());
 
 		theExchange.endExchange();
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
@@ -1,16 +1,15 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
-import edu.stanford.protege.metaproject.api.ProjectId;
-import io.undertow.server.HttpServerExchange;
-import org.semanticweb.owlapi.model.OWLAxiom;
-
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import static io.undertow.util.StatusCodes.OK;
+import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.StatusCodes;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
 
 /**
  * @author Evren Sirin
@@ -28,10 +27,10 @@ public class ReasonerUpdateHandler extends AbstractRoutingHandler {
 
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final ProjectId projectId = getProjectId(theExchange);
+		final IRI ontology = getOntology(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
-		final SchemaReasoner aReasoner = getClientState(projectId, clientId).getReasoner();
+		final SchemaReasoner aReasoner = getClientState(ontology, clientId).getReasoner();
 
 		final Set<OWLAxiom> axioms = readAxioms(theExchange.getInputStream());
 
@@ -39,13 +38,14 @@ public class ReasonerUpdateHandler extends AbstractRoutingHandler {
 
 		if (insert) {
 			aReasoner.insert(axioms);
-		} else {
+		}
+		else {
 			aReasoner.delete(axioms);
 		}
 
 		LOGGER.info("Updating client " + clientId + " Success!");
 
-		theExchange.setStatusCode(OK);
+		theExchange.setStatusCode(StatusCodes.OK);
 		theExchange.endExchange();
 	}
 }

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
@@ -1,15 +1,16 @@
 package com.clarkparsia.pellet.server.handlers;
 
+import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
+import edu.stanford.protege.metaproject.api.ProjectId;
+import io.undertow.server.HttpServerExchange;
+import org.semanticweb.owlapi.model.OWLAxiom;
+
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.clarkparsia.pellet.service.reasoner.SchemaReasoner;
-import io.undertow.server.HttpServerExchange;
-import io.undertow.util.StatusCodes;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAxiom;
+import static io.undertow.util.StatusCodes.OK;
 
 /**
  * @author Evren Sirin
@@ -27,10 +28,10 @@ public class ReasonerUpdateHandler extends AbstractRoutingHandler {
 
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final IRI ontology = getOntology(theExchange);
+		final ProjectId projectId = getProjectId(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
-		final SchemaReasoner aReasoner = getClientState(ontology, clientId).getReasoner();
+		final SchemaReasoner aReasoner = getClientState(projectId, clientId).getReasoner();
 
 		final Set<OWLAxiom> axioms = readAxioms(theExchange.getInputStream());
 
@@ -38,14 +39,13 @@ public class ReasonerUpdateHandler extends AbstractRoutingHandler {
 
 		if (insert) {
 			aReasoner.insert(axioms);
-		}
-		else {
+		} else {
 			aReasoner.delete(axioms);
 		}
 
 		LOGGER.info("Updating client " + clientId + " Success!");
 
-		theExchange.setStatusCode(StatusCodes.OK);
+		theExchange.setStatusCode(OK);
 		theExchange.endExchange();
 	}
 }

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerUpdateHandler.java
@@ -20,7 +20,7 @@ public class ReasonerUpdateHandler extends AbstractRoutingHandler {
 
 	public ReasonerUpdateHandler(final ProtegeServerState theServerState,
 	                             final boolean insert) {
-		super("POST", "{ontology}/" + (insert ? "insert" : "delete"), theServerState);
+		super("POST", (insert ? "insert" : "delete"), theServerState);
 
 		this.insert = insert;
 	}

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
@@ -1,14 +1,16 @@
 package com.clarkparsia.pellet.server.handlers;
 
+import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.google.inject.Inject;
+import edu.stanford.protege.metaproject.api.ProjectId;
+import io.undertow.server.HttpServerExchange;
+
 import java.util.UUID;
 
-import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.google.common.net.MediaType;
-import com.google.inject.Inject;
-import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Headers;
-import io.undertow.util.StatusCodes;
-import org.semanticweb.owlapi.model.IRI;
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static io.undertow.util.Headers.CONTENT_TYPE;
+import static io.undertow.util.StatusCodes.OK;
+import static java.lang.String.valueOf;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -25,15 +27,15 @@ public class ReasonerVersionHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final IRI ontology = getOntology(theExchange);
+		final ProjectId projectId = getProjectId(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
 		// Get local client reasoner's version
-		int version = getClientState(ontology, clientId).version();
+		int version = getClientState(projectId, clientId).version();
 
-		theExchange.setStatusCode(StatusCodes.OK);
-		theExchange.getResponseHeaders().put(Headers.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString());
-		theExchange.getResponseSender().send(String.valueOf(version));
+		theExchange.setStatusCode(OK);
+		theExchange.getResponseHeaders().put(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString());
+		theExchange.getResponseSender().send(valueOf(version));
 		theExchange.endExchange();
 	}
 }

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
@@ -1,16 +1,14 @@
 package com.clarkparsia.pellet.server.handlers;
 
-import com.clarkparsia.pellet.server.protege.ProtegeServerState;
-import com.google.inject.Inject;
-import edu.stanford.protege.metaproject.api.ProjectId;
-import io.undertow.server.HttpServerExchange;
-
 import java.util.UUID;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static io.undertow.util.Headers.CONTENT_TYPE;
-import static io.undertow.util.StatusCodes.OK;
-import static java.lang.String.valueOf;
+import com.clarkparsia.pellet.server.protege.ProtegeServerState;
+import com.google.common.net.MediaType;
+import com.google.inject.Inject;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
+import org.semanticweb.owlapi.model.IRI;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -27,15 +25,15 @@ public class ReasonerVersionHandler extends AbstractRoutingHandler {
 	 */
 	@Override
 	public void handleRequest(final HttpServerExchange theExchange) throws Exception {
-		final ProjectId projectId = getProjectId(theExchange);
+		final IRI ontology = getOntology(theExchange);
 		final UUID clientId = getClientID(theExchange);
 
 		// Get local client reasoner's version
-		int version = getClientState(projectId, clientId).version();
+		int version = getClientState(ontology, clientId).version();
 
-		theExchange.setStatusCode(OK);
-		theExchange.getResponseHeaders().put(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString());
-		theExchange.getResponseSender().send(valueOf(version));
+		theExchange.setStatusCode(StatusCodes.OK);
+		theExchange.getResponseHeaders().put(Headers.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString());
+		theExchange.getResponseSender().send(String.valueOf(version));
 		theExchange.endExchange();
 	}
 }

--- a/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/handlers/ReasonerVersionHandler.java
@@ -17,7 +17,7 @@ public class ReasonerVersionHandler extends AbstractRoutingHandler {
 
 	@Inject
 	public ReasonerVersionHandler(final ProtegeServerState theServerState) {
-		super("GET", "{ontology}/version", theServerState);
+		super("GET", "version", theServerState);
 	}
 
 	/**

--- a/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeOntologyState.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeOntologyState.java
@@ -10,10 +10,12 @@ package com.clarkparsia.pellet.server.protege;
 
 import com.clarkparsia.modularity.IncrementalReasoner;
 import com.clarkparsia.modularity.IncrementalReasonerConfiguration;
+import com.clarkparsia.owlapiv3.IRIUtils;
 import com.google.common.base.Charsets;
 import com.google.common.cache.*;
 import com.google.common.io.Files;
 import edu.stanford.protege.metaproject.api.ProjectId;
+import okhttp3.HttpUrl;
 import org.mindswap.pellet.utils.progress.ConsoleProgressMonitor;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.client.api.exception.AuthorizationException;
@@ -134,7 +136,8 @@ public class ProtegeOntologyState implements AutoCloseable {
 	}
 
 	public IRI getIRI() {
-		return ontology.getOntologyID().getOntologyIRI().orNull();
+		return ontology.getOntologyID().getOntologyIRI()
+			.transform(iri -> IRIUtils.addProjectId(iri, this.projectId.get())).orNull();
 	}
 
 	public boolean update() {

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
@@ -1,5 +1,6 @@
 package com.clarkparsia.pellet.server.protege;
 
+import com.clarkparsia.owlapiv3.IRIUtils;
 import com.clarkparsia.owlapiv3.OntologyUtils;
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
@@ -8,6 +9,7 @@ import com.google.common.io.Resources;
 import edu.stanford.protege.metaproject.ConfigurationManager;
 import edu.stanford.protege.metaproject.api.PolicyFactory;
 import edu.stanford.protege.metaproject.api.Project;
+import edu.stanford.protege.metaproject.api.ProjectId;
 import edu.stanford.protege.metaproject.api.ProjectOptions;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.BasicConfigurator;
@@ -90,23 +92,24 @@ public abstract class ProtegeServerTest {
 	}
 
 	protected static IRI createOwl2Ontology(final LocalHttpClient client) throws Exception {
-		createOntology(OWL2_ONT, OWL2_FILE, client);
-		return IRI.create("http://www.example.org/test");
+		final ProjectId projectId = createOntology(OWL2_ONT, OWL2_FILE, client);
+		return IRIUtils.addProjectId(IRI.create("http://www.example.org/test"), projectId.get());
 	}
 
 	protected static IRI createAgenciesOntology(final LocalHttpClient client) throws Exception {
-		createOntology(AGENCIES_ONT, AGENCIES_FILE, client);
-		return  IRI.create("http://www.owl-ontologies.com/unnamed.owl");
+		final ProjectId projectId = createOntology(AGENCIES_ONT, AGENCIES_FILE, client);
+		return IRIUtils.addProjectId(IRI.create("http://www.owl-ontologies.com/unnamed.owl"), projectId.get());
 	}
 
-	protected static void createOntology(final String resourceName, final File ont, final LocalHttpClient client) throws Exception {
+	protected static ProjectId createOntology(final String resourceName, final File ont, final LocalHttpClient client) throws Exception {
 		PolicyFactory f = ConfigurationManager.getFactory();
-		Project p = f.getProject(f.getProjectId(resourceName),
+		final ProjectId projectId = f.getProjectId(resourceName);
+		Project p = f.getProject(projectId,
 		                         f.getName(resourceName),
 		                         f.getDescription(resourceName),
 		                         f.getUserId("admin"),
 		                         Optional.<ProjectOptions>absent());
-		ServerDocument s = client.createProject(p, ont);
-		System.out.println(s);
+		client.createProject(p, ont);
+		return projectId;
 	}
 }

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/ProtegeServerTest.java
@@ -1,7 +1,7 @@
 package com.clarkparsia.pellet.server.protege;
 
-import com.clarkparsia.owlapiv3.IRIUtils;
 import com.clarkparsia.owlapiv3.OntologyUtils;
+import com.clarkparsia.pellet.server.protege.model.ProjectIRI;
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.io.Files;
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.server.http.HTTPServer;
-import org.protege.editor.owl.server.versioning.api.ServerDocument;
 import org.semanticweb.owlapi.model.IRI;
 
 import java.io.File;
@@ -91,14 +90,14 @@ public abstract class ProtegeServerTest {
 		OntologyUtils.clearOWLOntologyManager();
 	}
 
-	protected static IRI createOwl2Ontology(final LocalHttpClient client) throws Exception {
+	protected static ProjectIRI createOwl2Ontology(final LocalHttpClient client) throws Exception {
 		final ProjectId projectId = createOntology(OWL2_ONT, OWL2_FILE, client);
-		return IRIUtils.addProjectId(IRI.create("http://www.example.org/test"), projectId.get());
+		return new ProjectIRI(IRI.create("http://www.example.org/test"), projectId);
 	}
 
-	protected static IRI createAgenciesOntology(final LocalHttpClient client) throws Exception {
+	protected static ProjectIRI createAgenciesOntology(final LocalHttpClient client) throws Exception {
 		final ProjectId projectId = createOntology(AGENCIES_ONT, AGENCIES_FILE, client);
-		return IRIUtils.addProjectId(IRI.create("http://www.owl-ontologies.com/unnamed.owl"), projectId.get());
+		return new ProjectIRI(IRI.create("http://www.owl-ontologies.com/unnamed.owl"), projectId);
 	}
 
 	protected static ProjectId createOntology(final String resourceName, final File ont, final LocalHttpClient client) throws Exception {

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProjectIRI.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProjectIRI.java
@@ -1,0 +1,26 @@
+package com.clarkparsia.pellet.server.protege.model;
+
+import com.clarkparsia.owlapiv3.IRIUtils;
+import edu.stanford.protege.metaproject.api.ProjectId;
+import org.semanticweb.owlapi.model.IRI;
+
+/**
+ * Created by rgrinberg on 7/26/17.
+ */
+public class ProjectIRI {
+	private final IRI iri;
+	public final ProjectId projectId;
+
+	public ProjectIRI(IRI iri, ProjectId projectId) {
+		this.iri = iri;
+		this.projectId = projectId;
+	}
+
+	public IRI rawIRI() {
+		return iri;
+	}
+
+	public IRI projectIRI() {
+		return IRIUtils.addProjectId(this.iri, this.projectId.get());
+	}
+}

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -79,9 +79,9 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 		assertEquals(ontologies.size(), mServerState.ontologies().size());
 		for (String ontology : ontologies) {
 			IRI ontologyIRI = IRI.create(ontology);
-//			Optional<ProtegeOntologyState> state = mServerState.getOntology(ontologyIRI);
-//			assertTrue(state.isPresent());
-//			assertEquals(ontologyIRI, state.get().getIRI());
+			Optional<ProtegeOntologyState> state = mServerState.getOntology(ontologyIRI);
+			assertTrue(state.isPresent());
+			assertEquals(ontologyIRI, state.get().getIRI());
 		}
 	}
 
@@ -93,14 +93,14 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 	@Test
 	public void addRemoveOntologies() throws Exception {
 		for (String s : ONTOLOGIES1) {
-//			assertTrue(mServerState.removeOntology(IRI.create(s)));
+			assertTrue(mServerState.removeOntology(IRI.create(s)));
 		}
 		assertOntologies(Lists.<String>newArrayList());
 	}
 
 	@Test
 	public void removeNotExists() throws Exception {
-//		assertFalse(mServerState.removeOntology(IRI.create("http://www.example.com/does-not-exist")));
+		assertFalse(mServerState.removeOntology(IRI.create("http://www.example.com/does-not-exist")));
 	}
 
 	@Test

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -37,7 +37,6 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 	public static final List<String> ONTOLOGIES = Lists.<String>newArrayList(OWL2_ONT, AGENCIES_ONT);
 	public String agencies;
 	public String owl2;
-	public List<String> ontologies1 = Lists.newArrayList(owl2, agencies);
 	ProtegeServerState mServerState;
 
 	@Before
@@ -58,9 +57,8 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 			managerPassword.getPassword(),
 			protegeSettings.host() + ":8081");
 
-		owl2 = createOwl2Ontology(managerClient).toString();
-		agencies = createAgenciesOntology(managerClient).toString();
-		ontologies1 = Lists.newArrayList(owl2, agencies);
+		owl2 = createOwl2Ontology(managerClient).projectIRI().toString();
+		agencies = createAgenciesOntology(managerClient).projectIRI().toString();
 
 		mServerState.close();
 
@@ -87,12 +85,12 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 
 	@Test
 	public void shouldHaveOntologies() throws Exception {
-		assertOntologies(ontologies1);
+		assertOntologies(Lists.newArrayList(owl2, agencies));
 	}
 
 	@Test
 	public void addRemoveOntologies() throws Exception {
-		for (String s : ontologies1) {
+		for (String s : Lists.newArrayList(owl2, agencies)) {
 			assertTrue(mServerState.removeOntology(IRI.create(s)));
 		}
 		assertOntologies(Lists.<String>newArrayList());

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -79,9 +79,9 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 		assertEquals(ontologies.size(), mServerState.ontologies().size());
 		for (String ontology : ontologies) {
 			IRI ontologyIRI = IRI.create(ontology);
-			Optional<ProtegeOntologyState> state = mServerState.getOntology(ontologyIRI);
-			assertTrue(state.isPresent());
-			assertEquals(ontologyIRI, state.get().getIRI());
+//			Optional<ProtegeOntologyState> state = mServerState.getOntology(ontologyIRI);
+//			assertTrue(state.isPresent());
+//			assertEquals(ontologyIRI, state.get().getIRI());
 		}
 	}
 
@@ -93,14 +93,14 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 	@Test
 	public void addRemoveOntologies() throws Exception {
 		for (String s : ONTOLOGIES1) {
-			assertTrue(mServerState.removeOntology(IRI.create(s)));
+//			assertTrue(mServerState.removeOntology(IRI.create(s)));
 		}
 		assertOntologies(Lists.<String>newArrayList());
 	}
 
 	@Test
 	public void removeNotExists() throws Exception {
-		assertFalse(mServerState.removeOntology(IRI.create("http://www.example.com/does-not-exist")));
+//		assertFalse(mServerState.removeOntology(IRI.create("http://www.example.com/does-not-exist")));
 	}
 
 	@Test

--- a/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
+++ b/server/src/test/java/com/clarkparsia/pellet/server/protege/model/ProtegeServerStateTest.java
@@ -23,7 +23,6 @@ import org.semanticweb.owlapi.model.IRI;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -35,11 +34,10 @@ import static org.junit.Assert.assertTrue;
  */
 public class ProtegeServerStateTest extends ProtegeServerTest {
 
-	public static final ArrayList<String> ONTOLOGIES = Lists.<String>newArrayList(OWL2_ONT, AGENCIES_ONT);
-	public static final String HTTP_WWW_OWL_ONTOLOGIES_COM_UNNAMED_OWL = "http://www.owl-ontologies.com/unnamed.owl";
-	public static final String HTTP_WWW_EXAMPLE_ORG_TEST = "http://www.example.org/test";
-	public static final ArrayList<String> ONTOLOGIES1 = Lists.newArrayList(
-		HTTP_WWW_EXAMPLE_ORG_TEST, HTTP_WWW_OWL_ONTOLOGIES_COM_UNNAMED_OWL);
+	public static final List<String> ONTOLOGIES = Lists.<String>newArrayList(OWL2_ONT, AGENCIES_ONT);
+	public String agencies;
+	public String owl2;
+	public List<String> ontologies1 = Lists.newArrayList(owl2, agencies);
 	ProtegeServerState mServerState;
 
 	@Before
@@ -60,8 +58,10 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 			managerPassword.getPassword(),
 			protegeSettings.host() + ":8081");
 
-		createOwl2Ontology(managerClient);
-		createAgenciesOntology(managerClient);
+		owl2 = createOwl2Ontology(managerClient).toString();
+		agencies = createAgenciesOntology(managerClient).toString();
+		ontologies1 = Lists.newArrayList(owl2, agencies);
+
 		mServerState.close();
 
 		injector = Guice.createInjector(Modules.override(new PelletServerModule())
@@ -87,12 +87,12 @@ public class ProtegeServerStateTest extends ProtegeServerTest {
 
 	@Test
 	public void shouldHaveOntologies() throws Exception {
-		assertOntologies(ONTOLOGIES1);
+		assertOntologies(ontologies1);
 	}
 
 	@Test
 	public void addRemoveOntologies() throws Exception {
-		for (String s : ONTOLOGIES1) {
+		for (String s : ontologies1) {
 			assertTrue(mServerState.removeOntology(IRI.create(s)));
 		}
 		assertOntologies(Lists.<String>newArrayList());

--- a/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
+++ b/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
@@ -1,8 +1,0 @@
-package com.clarkparsia.pellet.service;
-
-/**
- * Created by rgrinberg on 7/24/17.
- */
-public class PelletServiceConstants {
-	public static final String PROJECT_ID_HEADER = "X-projectId";
-}

--- a/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
+++ b/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
@@ -1,0 +1,8 @@
+package com.clarkparsia.pellet.service;
+
+/**
+ * Created by rgrinberg on 7/24/17.
+ */
+public class PelletServiceConstants {
+	public static final String PROJECT_ID_HEADER = "X-projectId";
+}

--- a/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
+++ b/shared/src/main/java/com/clarkparsia/pellet/service/PelletServiceConstants.java
@@ -5,4 +5,6 @@ package com.clarkparsia.pellet.service;
  */
 public class PelletServiceConstants {
 	public static final String PROJECT_ID_HEADER = "X-projectId";
+	public static final String PROJECT_ID = "projectId";
+	public static final String ONTOLOGY = "ontology";
 }


### PR DESCRIPTION
The project id can now be added by initing the client module with an appropriate
provider that fetches the current project id. For example, from the client state.