### PR TITLE
Fix logging when IRI is missing

### DIFF
--- a/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeOntologyState.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeOntologyState.java
@@ -11,6 +11,7 @@ package com.clarkparsia.pellet.server.protege;
 import com.clarkparsia.modularity.IncrementalReasoner;
 import com.clarkparsia.modularity.IncrementalReasonerConfiguration;
 import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
 import com.google.common.cache.*;
 import com.google.common.io.Files;
 import edu.stanford.protege.metaproject.api.ProjectId;
@@ -133,8 +134,8 @@ public class ProtegeOntologyState implements AutoCloseable {
 		}
 	}
 
-	public IRI getIRI() {
-		return ontology.getOntologyID().getOntologyIRI().orNull();
+	public Optional<IRI> getIRI() {
+		return ontology.getOntologyID().getOntologyIRI();
 	}
 
 	public boolean update() {
@@ -185,13 +186,13 @@ public class ProtegeOntologyState implements AutoCloseable {
 				reasoner.save(path.toFile());
 			}
 		} catch (IOException theE) {
-			LOGGER.log(Level.SEVERE, "Couldn't save the OntologyState " + getIRI().toQuotedString(), theE);
+			LOGGER.log(Level.SEVERE, "Couldn't save the OntologyState " + toString(), theE);
 		}
 
 		try {
 			writeRevision();
 		} catch (IOException theE) {
-			LOGGER.log(Level.SEVERE, "Couldn't save the ontology state " + getIRI().toQuotedString(), theE);
+			LOGGER.log(Level.SEVERE, "Couldn't save the ontology state " + toString(), theE);
 		}
 	}
 
@@ -209,8 +210,7 @@ public class ProtegeOntologyState implements AutoCloseable {
 
 	@Override
 	public String toString() {
-		IRI iri = getIRI();
-		return "State(" + (iri == null ? "Anonymous ontology" : iri) + ")";
+		return String.format("ProtegeOntologyState(projectId=%s, iri=%s)", projectId.get(), getIRI());
 	}
 
 	private LoadingCache<UUID, ClientState> initClientCache() {

--- a/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeServerState.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/protege/ProtegeServerState.java
@@ -115,11 +115,12 @@ public final class ProtegeServerState {
 			System.out.println(e.getMessage());
 			throw new OWLOntologyCreationException("Could not load ontology from Protege server: " + ontologyPath, e);
 		}
-		if (result.getIRI() == null) {
+		if (result.getIRI().isPresent()) {
+			ontologies.put(result.getIRI().get(), result);
+			return result;
+		} else {
 			throw new RuntimeException("Failed to get IRI for " + ontologyPath);
 		}
-		ontologies.put(result.getIRI(), result);
-		return result;
 	}
 
 	public boolean removeOntology(final IRI ontology) {


### PR DESCRIPTION
Currently, the logging would fail b/c the IRI isn't always present. This commit
makes sure the logging always succeeds and also includes the projectId.