### PR TITLE
Remove unnecessary call

### DIFF
--- a/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
+++ b/server/src/main/java/com/clarkparsia/pellet/server/PelletServer.java
@@ -196,7 +196,7 @@ public final class PelletServer {
                         stop();
                         try {
                             start();
-                            getState().start();
+                            //getState().start();
                         } catch (ServerException e) {
                             throw new RuntimeException(e);
                         }


### PR DESCRIPTION
@rgrinberg @AnthonyMl - have a look at this. I think this call is not needed. On restart, the main `start()` call creates a new `ProtegeServerState` and the `start()` method is called in it's constructor.

The behavior I was seeing, which this fixes, is that after a restart the first request from a client failed, because the `ontologies` map state variable was empty.